### PR TITLE
Update git repo URL

### DIFF
--- a/frontend/src/Tutorial.md
+++ b/frontend/src/Tutorial.md
@@ -15,7 +15,7 @@ You can run this tutorial by:
 2. Cloning the calculator-tutorial repository.
 
     ```bash
-    git clone git@github.com:obsidiansystems/calculator-tutorial
+    git clone https://github.com/obsidiansystems/calculator-tutorial.git
     ```
 
 3. Running the application with the `ob` command.


### PR DESCRIPTION
GitHub no longer allows unauthenticated use of the `git://` protocol, so `https://` should be used instead.

Reference: <https://github.blog/2021-09-01-improving-git-protocol-security-github/>